### PR TITLE
Add ruby 1.8.7 to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem 'rake',                    :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'rspec', '~> 3.2.0'
+  gem 'rspec', '~> 3.1.0'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
+group :development do
+  gem 'beaker-rspec'
+end
+
 group :development, :test do
   gem 'rake',                    :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
   gem 'rspec', '~> 3.2.0'
 end
 


### PR DESCRIPTION
Ruby 1.8 is still around for centos6 users, so try and ensure we
still build OK there.
